### PR TITLE
用 Travis 自动生成 OPML

### DIFF
--- a/.build/buildOpml.sh
+++ b/.build/buildOpml.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+scriptpath=$(readlink "$0")
+basedir=$(dirname $(dirname "$scriptpath"))
+
+cd "$basedir"
+
+# Extracting table from README.md
+table=$(awk 'BEGIN {s=0};
+               /^##/ {s=0};
+               /^## List/ {s=1; next};
+               /^\s*$/ {next};
+               s {print}' ./README.md)
+
+# Trim header
+content=$(echo "$table" | tail -n +3)
+
+# Generation
+echo "
+<opml version=\"2.0\">
+  <head>
+    <title>${OPML_TITLE}</title>
+  </head>
+  <body>
+"
+
+echo "$content" | while read -r line || [[ -n "$line" ]]; do
+  name=$(echo $line | cut -f2 -d\| | sed 's/[ \t]*$//;s/^[ \t]*//')
+  xml=$(echo $line | cut -f3 -d\| | sed 's/[ \t]*$//;s/^[ \t]*//')
+  html=$(echo $line | cut -f4 -d\| | sed 's/[ \t]*$//;s/^[ \t]*//')
+  echo "<outline title=\"$name\" xmlUrl=\"$xml\" htmlUrl=\"$html\"/>"
+done
+
+echo "
+  </body>
+</opml>
+"

--- a/.build/push.sh
+++ b/.build/push.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Reference: https://gist.github.com/willprice/e07efd73fb7f13f917ea
+
+scriptpath=$(readlink "$0")
+basedir=$(dirname $(dirname "$scriptpath"))
+
+cd "$basedir"
+
+git config --global user.email "ci@travis-ci.org"
+git config --global user.name "Travis CI"
+
+git remote add origin-travis https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}
+
+
+git fetch origin-travis
+git add opml.xml
+git stash
+
+git checkout origin-travis/gh-pages || git checkout --orphan gh-pages
+git checkout stash -- opml.xml
+git reset
+git add opml.xml
+git commit -m "Travis build: $TRAVIS_BUILD_NUMBER"
+git push origin-travis HEAD:gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: generic
+
+branches:
+  only:
+    - master
+
+before_install:
+  - sudo apt-get install git
+
+script:
+  - .build/buildOpml.sh > opml.xml
+
+after_success:
+  - .build/push.sh


### PR DESCRIPTION
支持情况:
inoreader 可以订阅
feedly 可以下载之后导入

使用方法：
在 Github - Settings - Developer - Personal access tokens 新建一个 Token，有 public_repo 权限。这个会导致 token 持有者可以对 public_repo 干任何事情，咱们有 TUNABot 嘛？
在 Travis 打开这个项目，设置里填一个环境变量 GH_TOKEN，是上面得到的 Token，以及 OPML_TITLE，是生成的opml的标题
每次对master的push会更新gh-pages分支里面的opml.xml